### PR TITLE
Replace Emscripten API (Emscripten 3.1.55).

### DIFF
--- a/kaios/engine_template.html
+++ b/kaios/engine_template.html
@@ -78,22 +78,10 @@
 	<script id='engine-loader' type='text/javascript' src="dmloader.js"></script>
 	<!-- -->
 	<script id='engine-setup' type='text/javascript'>
-	var extra_params = {
-		archive_location_filter: function( path ) {
-			return ("{{DEFOLD_ARCHIVE_LOCATION_PREFIX}}" + path + "{{DEFOLD_ARCHIVE_LOCATION_SUFFIX}}");
-		},
-		engine_arguments: [{{#DEFOLD_ENGINE_ARGUMENTS}}"{{.}}",{{/DEFOLD_ENGINE_ARGUMENTS}}],
-		custom_heap_size: {{DEFOLD_HEAP_SIZE}},
-		full_screen_container: "#canvas-container",
-		disable_context_menu: true
-	}
-
-	Module['INITIAL_MEMORY'] = extra_params.custom_heap_size;
-
 	Module['isWASMSupported'] = false;
 
 	Module['onRuntimeInitialized'] = function() {
-		Module.runApp("canvas", extra_params);
+		Module.runApp("canvas");
 	};
 
 	Module["locateFile"] = function(path, scriptDirectory)

--- a/kaios/lib/web/kaios.js
+++ b/kaios/lib/web/kaios.js
@@ -11,7 +11,7 @@ var KaiOSLibrary = {
             console.log("keydown", event);
             {{{ makeDynCall("vii", "Context.listener") }}} (
                 1,
-                allocate(intArrayFromString(event.key), ALLOC_STACK)
+                stringToUTF8OnStack(event.key)
             );
         }, { passive: false });
 
@@ -19,11 +19,11 @@ var KaiOSLibrary = {
             console.log("keyup", event);
             {{{ makeDynCall("vii", "Context.listener") }}} (
                 0,
-                allocate(intArrayFromString(event.key), ALLOC_STACK)
+                stringToUTF8OnStack(event.key)
             );
         }, { passive: false });
     }
 }
 
 autoAddDeps(KaiOSLibrary, "$Context");
-mergeInto(LibraryManager.library, KaiOSLibrary);
+addToLibrary(KaiOSLibrary);


### PR DESCRIPTION
Relates to Emscripten update (https://github.com/defold/defold/pull/8766) and dmloader.js rework(https://github.com/defold/defold/pull/8682)